### PR TITLE
Build/rpm

### DIFF
--- a/.github/workflows/release-rpms.yml
+++ b/.github/workflows/release-rpms.yml
@@ -67,7 +67,6 @@ jobs:
       # Cache the from-source dlib wheel on aarch64
       - name: Cache dlib wheel
         if: matrix.name == 'aarch64'
-        if: matrix.name == 'aarch64'
         uses: actions/cache@v4
         with:
           path: wheels-cache

--- a/.github/workflows/release-rpms.yml
+++ b/.github/workflows/release-rpms.yml
@@ -1,0 +1,129 @@
+
+name: Build RPM packages
+
+# Builds binary .rpm packages for x86_64, x86_64 (x86-64-v3) and aarch64,
+# uploads & attaches to release.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  FEDORA_IMAGE: fedora:44
+
+jobs:
+  build:
+    name: build (${{ matrix.name }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Baseline x86_64.
+          - name: x86_64
+            runner: ubuntu-24.04
+            march: ""
+            rel_suffix: ""
+            vendor_mediapipe: "true"
+            smoke: "true"
+          # x86-64-v3 micro-architecture optimised build.
+          - name: x86_64_v3
+            runner: ubuntu-24.04
+            march: "x86-64-v3"
+            rel_suffix: ".v3"
+            vendor_mediapipe: "true"
+            smoke: "false"
+          # aarch64 (native runner).
+          - name: aarch64
+            runner: ubuntu-24.04-arm
+            march: ""
+            rel_suffix: ""
+            vendor_mediapipe: "false"
+            smoke: "true"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine package version
+        id: ver
+        run: |
+          version="0.1.1"
+          if [ "${{ github.event_name }}" = "release" ]; then
+            tag="${{ github.ref_name }}"
+            version="${tag#v}"
+          fi
+          if [ -z "$version" ]; then
+            echo "::error::Could not determine package version (empty)."
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Building secure-eye $version (${{ matrix.name }})"
+
+      # Cache the from-source dlib wheel on aarch64
+      - name: Cache dlib wheel
+        if: matrix.name == 'aarch64'
+        if: matrix.name == 'aarch64'
+        uses: actions/cache@v4
+        with:
+          path: wheels-cache
+          key: dlib-wheel-${{ runner.arch }}-${{ env.FEDORA_IMAGE }}
+
+      - name: Build packages (Fedora container)
+        run: |
+          docker run --rm -v "$PWD:/src" -w /src "$FEDORA_IMAGE" \
+            env PKG_VERSION="${{ steps.ver.outputs.version }}" \
+                MARCH="${{ matrix.march }}" \
+                REL_SUFFIX="${{ matrix.rel_suffix }}" \
+                VENDOR_MEDIAPIPE="${{ matrix.vendor_mediapipe }}" \
+            bash scripts/build-rpm.sh
+
+      - name: Save dlib wheel to cache
+        if: matrix.name == 'aarch64'
+        run: |
+          mkdir -p wheels-cache
+          cp wheels/dlib-*.whl wheels-cache/ 2>/dev/null || true
+
+      - name: Install smoke test
+        if: matrix.smoke == 'true'
+        run: |
+          docker run --rm -v "$PWD/dist:/rpms:ro" "$FEDORA_IMAGE" bash -euc '
+            dnf install -y /rpms/*.rpm
+            rpm -q libpam-secureeye secureeye-authd secure-eye
+            # %post must have built the recognition venv offline from the wheels.
+            test -x /usr/lib/secureeye-authd/venv/bin/python3
+            id secureeye
+            test -f /usr/lib/systemd/system/secureeye-authd.service
+            test -f /usr/lib64/security/pam_secureEye.so
+            echo "Install smoke test passed."
+          '
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rpm-${{ matrix.name }}
+          path: dist/*.rpm
+          if-no-files-found: error
+
+  release:
+    name: Attach to release
+    needs: build
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: rpm-*
+          merge-multiple: true
+
+      - name: List downloaded packages
+        run: ls -la dist
+
+      - name: Upload to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*.rpm

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ wheels/
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# ...except the RPM package spec
+!secureEye/rpm/secure-eye.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -102,6 +102,45 @@ sudo add-apt-repository ppa:vhrabar/tools
 sudo apt update && sudo apt install secure-eye
 ```
 
+### Fedora, RHEL & RPM-based systems
+
+The easiest way is the
+[COPR repository](https://copr.fedorainfracloud.org/coprs/vhrabar/SecureEye/).
+
+On **Fedora**:
+
+```bash
+sudo dnf copr enable vhrabar/SecureEye
+sudo dnf install secure-eye
+```
+
+On **RHEL / CentOS Stream / Rocky / AlmaLinux** (enable EPEL first for the `copr`
+plugin and dependencies):
+
+```bash
+sudo dnf install epel-release
+sudo dnf copr enable vhrabar/SecureEye
+sudo dnf install secure-eye
+```
+
+This installs the same three packages as on Debian (`libpam-secureeye`,
+`secureeye-authd`, `secure-eye`). On install, `secureeye-authd` builds its
+recognition virtualenv from the bundled wheels and enables the
+`secureeye-authd.service`.
+
+Alternatively, download the `.rpm` files from the
+[GitHub releases page](https://github.com/vhrabar/SecureEye/releases) and install
+them together:
+
+```bash
+sudo dnf install ./libpam-secureeye-*.rpm ./secureeye-authd-*.rpm ./secure-eye-*.rpm
+```
+
+> [!NOTE]
+> On Fedora/RHEL there is no `pam-auth-update`, so the PAM module is **not**
+> enabled automatically. Enable it as shown in **Usage step 3b** below (the
+> Debian-only `pam-auth-update` / `common-auth` steps do not apply).
+
 ---
 
 ## Usage
@@ -124,13 +163,34 @@ you later:
 sudo secureEye add
 ```
 
-**3. Make sure the PAM profile is enabled.** It is normally enabled automatically
-on install, but `pam-auth-update` will skip a profile it has already "seen" from a
-previous install. Verify (and enable if needed):
+**3. Make sure the PAM profile is enabled.**
+
+**3a) Ubuntu / Debian.** It is normally enabled automatically on install, but
+`pam-auth-update` will skip a profile it has already "seen" from a previous
+install. Verify (and enable if needed):
 
 ```bash
 grep -q pam_secureEye.so /etc/pam.d/common-auth && echo enabled || sudo pam-auth-update --enable secureEye.pam-config
 ```
+
+**3b) Fedora / RHEL.** There is no `pam-auth-update`; enable the module with an
+authselect custom profile:
+
+```bash
+sudo authselect create-profile secureeye -b local
+# Add this line near the top of the auth section of
+# /etc/authselect/custom/secureeye/{system,password}-auth:
+#   auth  sufficient  pam_secureEye.so
+sudo authselect select custom/secureeye --force
+```
+
+Or, for a single service (e.g. `sudo` only), add to `/etc/pam.d/sudo`:
+
+```
+auth  sufficient  pam_secureEye.so
+```
+
+Do **not** edit `/etc/pam.d/system-auth` directly as authselect overwrites it.
 
 **4. Try it.** Open a new terminal and run `sudo -i` — you should be able to
 authenticate by showing your face. If face auth fails or times out, SecureEye

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+st/*.rpm.
+set -euxo pipefail
+
+: "${PKG_VERSION:?PKG_VERSION is required}"
+VENDOR_MEDIAPIPE="${VENDOR_MEDIAPIPE:-true}"
+
+dnf install -y --setopt=install_weak_deps=False \
+    rpm-build rpmdevtools rpmlint git-core tar gzip \
+    meson ninja-build gcc-c++ pkgconf-pkg-config \
+    pam-devel libevdev-devel inih-devel \
+    python3-devel python3-pip systemd-rpm-macros \
+    cmake
+
+git config --global --add safe.directory "$PWD"
+rpmdev-setuptree
+
+# Source0: git archive of the tree
+git archive --format=tar.gz \
+    --prefix="secure-eye-${PKG_VERSION}/" \
+    -o "$HOME/rpmbuild/SOURCES/secure-eye-${PKG_VERSION}.tar.gz" HEAD
+
+# Source1: vendored wheels
+rm -rf wheels && mkdir -p wheels
+if [ "$VENDOR_MEDIAPIPE" = "true" ]; then
+    python3 -m pip download \
+        --only-binary=:all: --no-cache-dir --no-deps \
+        --platform manylinux_2_28_x86_64 \
+        --platform manylinux_2_17_x86_64 \
+        --platform manylinux2014_x86_64 \
+        --dest wheels \
+        -r requirements-vendor.txt
+else
+    grep -iv '^[[:space:]]*mediapipe' requirements-vendor.txt > /tmp/reqs.txt
+    python3 -m pip download \
+        --only-binary=:all: --no-cache-dir --no-deps \
+        --dest wheels \
+        -r /tmp/reqs.txt
+
+    if ls wheels-cache/dlib-*.whl >/dev/null 2>&1; then
+        echo "Reusing cached dlib wheel from wheels-cache/"
+        cp wheels-cache/dlib-*.whl wheels/
+    else
+        # Keep the version in sync with dlib_version in secure-eye.spec.
+        python3 -m pip wheel --no-deps --no-cache-dir --wheel-dir wheels "dlib==20.0.1"
+    fi
+fi
+ls -la wheels
+tar -cf "$HOME/rpmbuild/SOURCES/secureeye-wheels.tar" wheels
+
+# Source2: sysusers fragment
+cp secureEye/rpm/secureeye-authd.sysusers "$HOME/rpmbuild/SOURCES/"
+
+#  Build
+rpmbuild -bb secureEye/rpm/secure-eye.spec \
+    --define "pkg_version ${PKG_VERSION}" \
+    ${REL_SUFFIX:+--define "rel_suffix ${REL_SUFFIX}"} \
+    ${MARCH:+--define "march ${MARCH}"}
+
+mkdir -p dist
+cp "$HOME"/rpmbuild/RPMS/*/*.rpm dist/
+ls -la dist
+
+# report on err
+rpmlint dist/*.rpm || true

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-st/*.rpm.
 set -euxo pipefail
 
 : "${PKG_VERSION:?PKG_VERSION is required}"

--- a/scripts/build-rpm.sh
+++ b/scripts/build-rpm.sh
@@ -9,8 +9,8 @@ dnf install -y --setopt=install_weak_deps=False \
     rpm-build rpmdevtools rpmlint git-core tar gzip \
     meson ninja-build gcc-c++ pkgconf-pkg-config \
     pam-devel libevdev-devel inih-devel \
-    python3-devel python3-pip systemd-rpm-macros \
-    cmake
+    python3-devel python3-pip python3-setuptools python3-wheel systemd-rpm-macros \
+    cmake make openblas-devel libjpeg-turbo-devel libpng-devel
 
 git config --global --add safe.directory "$PWD"
 rpmdev-setuptree

--- a/secureEye/rpm/README.Fedora.md
+++ b/secureEye/rpm/README.Fedora.md
@@ -1,0 +1,39 @@
+
+# SecureEye on Fedora / RPM-based systems
+
+## PAM setup
+
+Fedora has no `pam-auth-update`, so the PAM profile shipped for
+Debian/Ubuntu (`usr/share/pam-configs/`) does not apply here. Enable the
+module with an authselect custom profile:
+
+```bash
+sudo authselect create-profile secureeye -b local
+# Add this line near the top of the auth section of
+# /etc/authselect/custom/secureeye/{system,password}-auth:
+#   auth  sufficient  pam_secureEye.so
+sudo authselect select custom/secureeye --force
+```
+
+Or, for a single service (e.g. sudo only), add to `/etc/pam.d/sudo`:
+
+```
+auth  sufficient  pam_secureEye.so
+```
+
+Do NOT edit `/etc/pam.d/system-auth` directly — authselect will
+overwrite it.
+
+## Runtime venv
+
+`secureeye-authd` builds its recognition virtualenv in
+`/usr/lib/secureeye-authd/venv` from bundled wheels during package
+installation (`%post`), fully offline. It is rebuilt on every upgrade
+and removed on erase.
+
+## Backends
+
+- x86_64 / x86_64 ("+v3" Release suffix): mediapipe backend (vendored wheel).
+- aarch64: dlib backend. Fedora does not package `python3-dlib`, so a
+  dlib wheel built from source is vendored into the package and the
+  shipped `config.ini` defaults to `detector_backend = dlib`.

--- a/secureEye/rpm/secure-eye.spec
+++ b/secureEye/rpm/secure-eye.spec
@@ -164,7 +164,7 @@ sed -i 's/^detector_backend = mediapipe/detector_backend = dlib/' \
 %endif
 
 %pre -n secureeye-authd
-%sysusers_create_compat %{SOURCE2}
+%sysusers_create_compat %{_sysusersdir}/secureeye-authd.conf
 
 %post -n secureeye-authd
 %systemd_post secureeye-authd.service

--- a/secureEye/rpm/secure-eye.spec
+++ b/secureEye/rpm/secure-eye.spec
@@ -1,0 +1,217 @@
+# RPM packaging for SecureEye
+#
+# CI passes:
+#   --define "pkg_version X.Y.Z"       (from the release tag)
+#   --define "rel_suffix .v3"          (x86-64-v3 build only)
+#   --define "march x86-64-v3"         (x86-64-v3 build only)
+#
+# Sources (created by scripts/build-rpm.sh):
+#   Source0  git archive of the tree
+#   Source1  tar of vendored wheels (wheels/*.whl)
+#   Source2  sysusers fragment
+
+%{!?pkg_version:%global pkg_version 0.1.1}
+
+
+%undefine __brp_python_bytecompile
+
+%global authd_home %{_prefix}/lib/secureeye-authd
+
+# dlib recognition backend for non-x86_64 -> temp till python3-dlib is
+# ported from ppa/vhrabar
+%global dlib_version 20.0.1
+
+Name:           secure-eye
+Version:        %{pkg_version}
+Release:        1%{?rel_suffix}%{?dist}
+Summary:        Transitional metapackage for SecureEye split packages
+License:        GPL-2.0-only AND MIT
+URL:            https://github.com/vhrabar/secureEye
+Source0:        %{name}-%{version}.tar.gz
+Source1:        secureeye-wheels.tar
+Source2:        secureeye-authd.sysusers
+
+BuildRequires:  meson >= 0.64
+BuildRequires:  ninja-build
+BuildRequires:  gcc-c++
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  pam-devel
+BuildRequires:  libevdev-devel
+# Provides INIReade
+BuildRequires:  inih-devel
+BuildRequires:  python3-devel
+BuildRequires:  systemd-rpm-macros
+
+# Non-x86_64 compiles the dlib wheel from source in %%build (see below).
+%ifnarch x86_64
+BuildRequires:  cmake
+BuildRequires:  make
+BuildRequires:  python3-pip
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-wheel
+BuildRequires:  openblas-devel
+BuildRequires:  libjpeg-turbo-devel
+BuildRequires:  libpng-devel
+%endif
+
+Requires:       libpam-secureeye = %{version}-%{release}
+Requires:       secureeye-authd = %{version}-%{release}
+
+%description
+Transitional metapackage that depends on the split SecureEye components
+(libpam-secureeye and secureeye-authd).
+
+%package -n libpam-secureeye
+Summary:        SecureEye PAM module
+
+%description -n libpam-secureeye
+C/C++ PAM module for SecureEye face-authentication integration.
+This package contains only PAM-facing components.
+
+Unlike Debian/Ubuntu there is no pam-auth-update on Fedora; enable the
+module manually or via an authselect custom profile (see README.Fedora.md).
+
+%package -n secureeye-authd
+Summary:        SecureEye authentication daemon and Python runtime components
+Requires:       python3 >= 3.12
+# %post builds the recognition venv with `python3 -m venv` + pip; on minimal
+# Fedora that tooling is not pulled in by python3 alone (deb needs python3-venv).
+Requires:       python3-pip
+Requires:       python3-numpy
+Requires:       python3-opencv
+Requires:       python3-matplotlib
+Requires:       python3-cffi
+Requires:       portaudio
+Requires:       v4l-utils
+Recommends:     libpam-secureeye
+%{?sysusers_requires_compat}
+%{?systemd_requires}
+# Wheels vendored into the runtime venv (see requirements-vendor.txt):
+Provides:       bundled(python3dist(mediapipe))
+Provides:       bundled(python3dist(ffmpeg-python))
+Provides:       bundled(python3dist(keyboard))
+
+%description -n secureeye-authd
+Helper daemon and Python runtime stack used by SecureEye face
+authentication. Includes systemd service assets and CLI tooling.
+The recognition virtualenv is built at install time (%%post) from
+wheels bundled in %{authd_home}/wheels — no network access is needed.
+
+%prep
+%autosetup -n %{name}-%{version}
+tar -xf %{SOURCE1}   # -> wheels/
+
+%build
+export CFLAGS="%{optflags}%{?march: -march=%{march}}"
+export CXXFLAGS="%{optflags}%{?march: -march=%{march}}"
+
+meson setup %{_vpath_builddir} . \
+    --wrap-mode=nodownload \
+    --buildtype=plain \
+    --prefix=%{_prefix} \
+    --sysconfdir=%{_sysconfdir} \
+    --localstatedir=%{_localstatedir} \
+    --libdir=%{_lib} \
+    -Dpython.bytecompile=-1 \
+    -Dinstall_pam_config=false \
+    -Dconfig_dir=%{_sysconfdir}/secureEye \
+    -Duser_models_dir=%{_sysconfdir}/secureEye/models
+meson compile -C %{_vpath_builddir}
+
+%ifnarch x86_64
+# build the dlib wheel from source for non-x86_64 arches (aarch64).
+if ! ls wheels/dlib-*.whl >/dev/null 2>&1; then
+    python3 -m pip wheel --no-deps --no-build-isolation --no-cache-dir \
+        --wheel-dir wheels "dlib==%{dlib_version}"
+fi
+%endif
+
+%install
+DESTDIR=%{buildroot} meson install -C %{_vpath_builddir}
+
+rm -rf %{buildroot}%{_datadir}/dlib-data
+
+# User models directory (user_models_dir).
+install -d -m 0755 %{buildroot}%{_sysconfdir}/secureEye/models
+
+# sysusers fragment.
+install -D -m 0644 %{SOURCE2} %{buildroot}%{_sysusersdir}/secureeye-authd.conf
+
+# Vendored wheels + venv requirements
+install -d -m 0755 %{buildroot}%{authd_home}/wheels
+%ifarch x86_64
+install -m 0644 requirements-vendor.txt %{buildroot}%{authd_home}/requirements.txt
+# skip the aarch64-only dlib wheel here.
+for whl in wheels/*.whl; do
+    case "$(basename "$whl")" in
+        dlib-*) echo "Skipping $whl on %{_arch}" ;;
+        *) cp "$whl" %{buildroot}%{authd_home}/wheels/ ;;
+    esac
+done
+%else
+
+grep -iv '^[[:space:]]*mediapipe' requirements-vendor.txt > reqs-filtered.txt
+echo 'dlib' >> reqs-filtered.txt
+install -m 0644 reqs-filtered.txt %{buildroot}%{authd_home}/requirements.txt
+for whl in wheels/*.whl; do
+    case "$(basename "$whl")" in
+        mediapipe-*) echo "Skipping $whl on %{_arch}" ;;
+        *) cp "$whl" %{buildroot}%{authd_home}/wheels/ ;;
+    esac
+done
+sed -i 's/^detector_backend = mediapipe/detector_backend = dlib/' \
+    %{buildroot}%{_sysconfdir}/secureEye/config.ini
+%endif
+
+%pre -n secureeye-authd
+%sysusers_create_compat %{SOURCE2}
+
+%post -n secureeye-authd
+%systemd_post secureeye-authd.service
+# Build (or rebuild on upgrade) the recognition venv from the bundled wheels.
+rm -rf %{authd_home}/venv
+python3 -m venv --system-site-packages %{authd_home}/venv
+# --no-deps: install the vendored wheels as-is
+%{authd_home}/venv/bin/pip install --no-index --no-deps --no-cache-dir \
+    --find-links %{authd_home}/wheels \
+    -r %{authd_home}/requirements.txt
+
+%preun -n secureeye-authd
+%systemd_preun secureeye-authd.service
+
+%postun -n secureeye-authd
+%systemd_postun_with_restart secureeye-authd.service
+if [ "$1" -eq 0 ]; then
+    rm -rf %{authd_home}/venv
+fi
+
+%files
+# metapackage: no files
+
+%files -n libpam-secureeye
+%license LICENSE licenses/MIT.txt
+%doc NOTICE secureEye/rpm/README.Fedora.md
+%{_libdir}/security/pam_secureEye.so
+
+%files -n secureeye-authd
+%license LICENSE licenses/MIT.txt
+%doc NOTICE README.md
+%{_bindir}/secureEye
+%{_libdir}/secureEye/
+%dir %{authd_home}
+%{authd_home}/wheels/
+%{authd_home}/requirements.txt
+%ghost %dir %{authd_home}/venv
+%{_unitdir}/secureeye-authd.service
+%{_sysusersdir}/secureeye-authd.conf
+%{_datadir}/bash-completion/completions/secureEye
+%dir %{_datadir}/secureEye
+%{_datadir}/secureEye/logo.png
+%{_mandir}/man1/SecureEye.1*
+%dir %{_sysconfdir}/secureEye
+%config(noreplace) %{_sysconfdir}/secureEye/config.ini
+%dir %{_sysconfdir}/secureEye/models
+
+%changelog
+* Thu Jul 02 2026 Vedran Hrabar <vedran.hrabar@outlook.com> - 0.1.1-1
+- Initial RPM packaging

--- a/secureEye/rpm/secureeye-authd.sysusers
+++ b/secureEye/rpm/secureeye-authd.sysusers
@@ -1,0 +1,1 @@
+u secureeye - "SecureEye daemon user" /nonexistent


### PR DESCRIPTION
This pull request introduces initial RPM packaging support for SecureEye, enabling builds and releases for Fedora and other RPM-based systems. It adds a complete GitHub Actions workflow for building and releasing RPMs, new packaging scripts, and Fedora-specific documentation. The packaging supports multiple architectures (x86_64, x86-64-v3, and aarch64), handles backend differences, and ensures fully offline installation by vendoring required Python wheels.

**RPM packaging and build automation:**
- Added `.github/workflows/release-rpms.yml` to automate building and releasing RPM packages for x86_64, x86-64-v3, and aarch64 on release or manual trigger, including smoke tests and artifact upload.
- Introduced `scripts/build-rpm.sh` for reproducible RPM builds in a Fedora container, including logic to vendor Python wheels (mediapipe for x86_64, dlib for aarch64), cache dlib builds, and prepare all sources for the RPM spec.

**RPM spec and packaging details:**
- Added `secureEye/rpm/secure-eye.spec` defining package structure, dependencies, build/install scripts, and architecture-specific logic for backend selection and wheel bundling. Also includes systemd, sysusers, and documentation integration.
- Added `secureEye/rpm/secureeye-authd.sysusers` to create a dedicated system user for the SecureEye daemon.

**COPR**
- Integrated with COPR (`vhrabar/SecureEye` projecyt), webhhok auto-release for Fedora and RHEL
