### PR TITLE
Fixes/detector caching

### DIFF
--- a/secureEye/src/auth/detector_factory.py
+++ b/secureEye/src/auth/detector_factory.py
@@ -2,12 +2,24 @@
 
 from __future__ import annotations
 
+import threading
 from dataclasses import dataclass
 from typing import Any
 
 
 class DetectorFactoryError(RuntimeError):
     """Raised when a detector backend cannot be initialized."""
+
+
+# cache build detector
+_detector_cache: dict[tuple, DetectorBundle] = {}
+_detector_cache_lock = threading.Lock()
+
+
+def _cache_key(config) -> tuple:
+    backend = config.get("core", "detector_backend", fallback="dlib").strip().lower()
+    use_cnn = config.getboolean("core", "use_cnn", fallback=False)
+    return (backend, use_cnn)
 
 
 @dataclass
@@ -23,6 +35,22 @@ def _is_missing_module(exc: ModuleNotFoundError, *candidates: str) -> bool:
 
 
 def create_detector(config) -> DetectorBundle:
+    """Return a detector backend for ``config``, building it once and caching it.
+
+    The first call for a given backend configuration builds the backend; every
+    subsequent call reuses the cached bundle.
+    """
+    key = _cache_key(config)
+    with _detector_cache_lock:
+        cached = _detector_cache.get(key)
+        if cached is not None:
+            return cached
+        bundle = _build_detector(config)
+        _detector_cache[key] = bundle
+        return bundle
+
+
+def _build_detector(config) -> DetectorBundle:
     """Create a detector backend from config.
 
     Supported values for [core] detector_backend:

--- a/secureEye/src/authd/main.py
+++ b/secureEye/src/authd/main.py
@@ -1,20 +1,27 @@
+import configparser
 import json
 import os
 import signal
 import socket
 import struct
 import sys
+import syslog
 import threading
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from dataclasses import dataclass
 
+import paths_factory
 from auth import ExitCode, AuthSession
+from auth.detector_factory import create_detector
 
 SOCKET_PATH = os.environ.get("SECUREEYE_AUTHD_SOCKET", "/run/secureeye/authd.sock")
 PROTO_VERSION = 1
 MAX_PAYLOAD = 4096
 DEFAULT_DEADLINE_MS = 2500
 INTERNAL_ERROR_CODE = 99
+
+# time between the daemon's own worker deadline and the client's transport deadline
+RESPONSE_MARGIN_MS = 700
 
 
 @dataclass
@@ -153,7 +160,7 @@ def _handle_client(conn: socket.socket, peer: str) -> None:
         payload = _read_frame(conn)
         req = _validate_payload(payload)
 
-        worker_timeout = max(0.1, (req.deadline_ms - 300) / 1000.0)
+        worker_timeout = max(0.1, (req.deadline_ms - RESPONSE_MARGIN_MS) / 1000.0)
 
         # Run auth in a worker and do not block daemon shutdown waiting for timed-out requests.
         session = AuthSession()
@@ -203,12 +210,29 @@ def _handle_client(conn: socket.socket, peer: str) -> None:
             pass
 
 
+def _warm_detector() -> None:
+    """
+    Build (and cache) the configured detector before serving requests.
+    """
+    try:
+        config = configparser.ConfigParser()
+        config.read(paths_factory.config_file_path())
+        create_detector(config)
+    except Exception as exc:
+        syslog.syslog(
+            syslog.LOG_WARNING,
+            f"secureeye-authd: detector warmup skipped: {exc}",
+        )
+
+
 def main() -> int:
     stop = threading.Event()
 
     # setup signal handling
     signal.signal(signal.SIGINT, lambda signum, _frame: stop.set())
     signal.signal(signal.SIGTERM, lambda signum, _frame: stop.set())
+
+    _warm_detector()
 
     # setup socket
     srv = _prepare_socket(SOCKET_PATH)

--- a/secureEye/src/pam/main.cc
+++ b/secureEye/src/pam/main.cc
@@ -602,7 +602,7 @@ auto identify(pam_handle_t *pamh, int flags, int argc, const char **argv,
       video_timeout_s > 0 ? static_cast<std::int64_t>(video_timeout_s) * 1000
                           : static_cast<std::int64_t>(AUTH_TIMEOUT_MS);
   const auto auth_timeout_ms = static_cast<int>(
-      std::clamp<std::int64_t>(configured_timeout_ms + 1500, 1000, 30000));
+      std::clamp<std::int64_t>(configured_timeout_ms + 1900, 1000, 30000));
 
   // NOTE: We should replace mutex and condition_variable by atomic wait, but
   // it's too recent (C++20)


### PR DESCRIPTION
This pull request introduces caching for detector backends in `detector_factory.py` and improves the startup performance and reliability of the authentication daemon by warming up the detector on launch. It also adjusts timeout margins to better coordinate between the PAM module and the daemon.

**Detector backend caching and warmup:**

* Added a cache (`_detector_cache`) and thread lock to `detector_factory.py` to ensure each detector backend is only built once per configuration, improving efficiency and thread safety. (`[secureEye/src/auth/detector_factory.pyR14-R24](diffhunk://#diff-70edfae0a5ca2eb67c12715541517df4e13a9beffed964f45ad754a4d14906adR14-R24)`)
* Modified `create_detector` to use this cache, building and storing detector bundles on first use. (`[secureEye/src/auth/detector_factory.pyR38-R53](diffhunk://#diff-70edfae0a5ca2eb67c12715541517df4e13a9beffed964f45ad754a4d14906adR38-R53)`)
* Added `_warm_detector()` to `authd/main.py` to pre-build and cache the detector at daemon startup, reducing latency for the first authentication request and logging a warning if warmup fails. (`Fe1a9782R210`)

**Timeout adjustments:**

* Introduced `RESPONSE_MARGIN_MS` in `authd/main.py` to better separate the daemon’s internal worker timeout from the client’s deadline, and updated its usage. (`[[1]](diffhunk://#diff-d0d3f49719fe1a58770350c3292014343db78dd18b8e0c6678ccec7a224c4735R1-R25)`, `[[2]](diffhunk://#diff-d0d3f49719fe1a58770350c3292014343db78dd18b8e0c6678ccec7a224c4735L156-R163)`)
* Increased the timeout margin in the PAM module (`main.cc`) from 1500ms to 1900ms to align with the daemon’s new margin and improve reliability. (`[secureEye/src/pam/main.ccL605-R605](diffhunk://#diff-674afb06633758d8dbcf4d100e242515e4ee5892485735c347283c72b22ebdbeL605-R605)`)
